### PR TITLE
Using local version of `mean_absolute_percentage_error()`

### DIFF
--- a/model_building/experiment_configuration.py
+++ b/model_building/experiment_configuration.py
@@ -24,7 +24,7 @@ from enum import Enum
 
 import numpy as np
 import matplotlib
-from sklearn.metrics import mean_squared_error, mean_absolute_percentage_error, r2_score
+from sklearn.metrics import mean_squared_error, r2_score
 
 matplotlib.use('Agg')
 # pylint: disable=wrong-import-position
@@ -53,6 +53,11 @@ enum_to_configuration_label = {Technique.LR_RIDGE: 'LRRidge', Technique.XGBOOST:
                                Technique.SVR: 'SVR', Technique.NNLS: 'NNLS',
                                Technique.STEPWISE: 'Stepwise'}
 
+
+def mean_absolute_percentage_error(y_true, y_pred):
+    epsilon = np.finfo(np.float64).eps
+    mape = np.abs(y_pred - y_true) / np.maximum(np.abs(y_true), epsilon)
+    return np.average(mape, axis=0)
 
 
 class ExperimentConfiguration(abc.ABC):

--- a/model_building/predictor.py
+++ b/model_building/predictor.py
@@ -20,7 +20,6 @@ import os
 import pickle
 import sys
 import pandas as pd
-from sklearn.metrics import mean_absolute_percentage_error
 
 import custom_logger
 import sequence_data_processing

--- a/model_building/wrapper_experiment_configuration.py
+++ b/model_building/wrapper_experiment_configuration.py
@@ -22,7 +22,7 @@ import mlxtend.feature_selection
 import numpy as np
 import pandas as pd
 import sklearn
-from sklearn.metrics import mean_absolute_percentage_error, r2_score, make_scorer
+from sklearn.metrics import r2_score, make_scorer
 from hyperopt import fmin, tpe, hp, STATUS_OK, Trials
 from hyperopt.pyll import scope
 import os

--- a/sequence_data_processing.py
+++ b/sequence_data_processing.py
@@ -30,8 +30,6 @@ import shutil
 import sys
 import time
 
-from sklearn.metrics import mean_absolute_percentage_error
-
 import custom_logger
 import data_preparation.column_selection
 import data_preparation.data_check


### PR DESCRIPTION
As only recent versions of scikit-learn implement those function. This will allow (hopefully) compatibility with Python 3.5.